### PR TITLE
feat: Add JSON file memory service used in e2e testing

### DIFF
--- a/code_agent/adk/json_memory_service.py
+++ b/code_agent/adk/json_memory_service.py
@@ -1,0 +1,193 @@
+"""Custom MemoryService implementation that persists sessions to a JSON file."""
+
+import ast  # Import ast for literal_eval
+import json
+import logging
+import os
+from dataclasses import dataclass  # Import dataclass
+from typing import Any, Dict, List, Tuple
+
+from google.adk.memory import BaseMemoryService
+from google.adk.sessions import Session
+
+logger = logging.getLogger(__name__)
+
+# Define type for the internal session storage key
+SessionKey = Tuple[str, str, str]  # (app_name, user_id, session_id)
+
+
+# Define a simple response structure for load_memory/search_memory
+@dataclass
+class MemoryServiceResponse:
+    memories: List[Dict[str, Any]]
+
+
+class JsonFileMemoryService(BaseMemoryService):
+    """
+    An implementation of BaseMemoryService that stores sessions in memory
+    and persists them to/loads them from a JSON file.
+
+    The load_memory implementation is a basic substring search.
+    """
+
+    def __init__(self, filepath: str):
+        """
+        Initializes the service, loading existing data from the JSON file if it exists.
+
+        Args:
+            filepath: The path to the JSON file for persistence.
+        """
+        super().__init__()
+        self.filepath = filepath
+        # Store Session objects directly, keyed by the tuple
+        self._sessions: Dict[SessionKey, Session] = {}
+        self._load_from_json()
+
+    def _get_session_key(self, session: Session) -> SessionKey:
+        """Helper to generate the dictionary key for a session."""
+        # Use the correct attribute name 'id' based on Session model
+        return (session.app_name, session.user_id, session.id)
+
+    def _load_from_json(self):
+        """Loads session data from the JSON file into the internal dictionary."""
+        if not os.path.exists(self.filepath):
+            logger.info(f"Memory file not found at {self.filepath}. Starting with empty memory.")
+            self._sessions = {}
+            return
+
+        logger.info(f"Loading memory from {self.filepath}...")
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                serialized_sessions: Dict[str, Dict[str, Any]] = json.load(f)
+
+            # Store validated Session objects
+            loaded_sessions: Dict[SessionKey, Session] = {}
+            for key_str, session_data in serialized_sessions.items():
+                try:
+                    # Convert string key back to tuple using safe evaluation
+                    key_tuple = ast.literal_eval(key_str)
+                    if not isinstance(key_tuple, tuple) or len(key_tuple) != 3:
+                        logger.warning(f"Invalid key format loaded from JSON: {key_str}. Skipping.")
+                        continue
+                    key: SessionKey = key_tuple  # Cast to type hint
+
+                    # Recreate Session object from stored data
+                    session = Session.model_validate(session_data)
+                    # Store the Session object with the correct tuple key
+                    loaded_sessions[key] = session
+                except (ValueError, SyntaxError, TypeError) as e:
+                    logger.warning(f"Failed to parse key {key_str}: {e}. Skipping.")
+                except Exception as e:
+                    logger.warning(f"Failed to validate session data for key {key_str}: {e}. Skipping.")
+            self._sessions = loaded_sessions
+            logger.info(f"Successfully loaded {len(self._sessions)} sessions from {self.filepath}.")
+
+        except FileNotFoundError:
+            logger.info(f"Memory file not found at {self.filepath}. Starting with empty memory.")
+            self._sessions = {}
+        except json.JSONDecodeError as e:
+            logger.error(f"Error decoding JSON from {self.filepath}: {e}. Starting with empty memory.")
+            self._sessions = {}
+        except Exception as e:
+            logger.error(f"Unexpected error loading memory from {self.filepath}: {e}. Starting with empty memory.")
+            self._sessions = {}
+
+    def _save_to_json(self):
+        """Saves the current internal session dictionary to the JSON file."""
+        logger.info(f"Saving memory ({len(self._sessions)} sessions) to {self.filepath}...")
+        # Serialize Session objects using Pydantic's model_dump
+        # Use a string representation of the tuple key for JSON compatibility
+        serialized_sessions: Dict[str, Dict[str, Any]] = {str(key): session.model_dump(mode="json") for key, session in self._sessions.items()}
+
+        try:
+            # Ensure directory exists
+            os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
+            with open(self.filepath, "w", encoding="utf-8") as f:
+                json.dump(serialized_sessions, f, indent=4)
+        except IOError as e:
+            logger.error(f"Error saving memory to {self.filepath}: {e}")
+        except TypeError as e:
+            logger.error(f"Unexpected error saving memory to {self.filepath}: {e}")
+
+    def add_session_to_memory(self, session: Session):
+        """
+        Adds a completed session to the memory store and persists to JSON.
+
+        Args:
+            session: The Session object to add.
+        """
+        # Add logging to see if runner calls this
+        logger.info(f"JsonFileMemoryService.add_session_to_memory called by Runner? Session ID: {getattr(session, 'session_id', 'N/A')}")
+
+        if not isinstance(session, Session):
+            logger.warning(f"Attempted to add non-Session object to memory: {type(session)}")
+            return
+
+        key = self._get_session_key(session)
+        logger.debug(f"Adding session with key {key} to memory.")
+        self._sessions[key] = session  # Store the session object
+        self._save_to_json()  # Persist after adding
+
+    def load_memory(self, query: str, **kwargs) -> MemoryServiceResponse:
+        """
+        Retrieves relevant information based on a query.
+
+        Args:
+            query: The natural language query string.
+            **kwargs: Additional keyword arguments (currently ignored).
+
+        Returns:
+            A MemoryServiceResponse containing a list of dictionaries,
+            each representing a relevant message's session data.
+        """
+        logger.info(f"Loading memory with query: '{query}'")
+        results: List[Dict[str, Any]] = []
+        query_lower = query.lower()
+
+        for session in self._sessions.values():  # Iterate over Session objects
+            session_matched = False
+            # Access history directly from the Session object
+            if session.history:
+                for message in session.history:
+                    # Access parts directly from the Content object in history
+                    message_text = ""
+                    if message.parts:
+                        message_text = "".join([part.text for part in message.parts if hasattr(part, "text") and part.text is not None]).lower()
+
+                    if query_lower in message_text:
+                        session_matched = True
+                        break  # Found a match in this session's history
+
+            if session_matched:
+                # Add relevant session data (e.g., the whole session dump)
+                results.append(session.model_dump(mode="json"))
+
+        logger.info(f"Found {len(results)} relevant session(s) for query: '{query}'")
+        # Return as an instance of the dataclass
+        return MemoryServiceResponse(memories=results)
+
+    # Implementing the abstract method required by BaseMemoryService
+    # Type hint reflects Base class, but implementation delegates to load_memory which returns MemoryServiceResponse
+    def search_memory(self, query: str, **kwargs) -> List[Dict[str, Any]]:
+        """
+        Searches the stored sessions for relevant information based on a query.
+        This method fulfills the abstract requirement from BaseMemoryService.
+        """
+        # For this implementation, search_memory simply delegates to load_memory.
+        # A more sophisticated implementation might differ.
+        logger.debug(f"search_memory called, delegating to load_memory for query: '{query}'")
+        response = self.load_memory(query, **kwargs)
+        # Base class expects List[Dict], extract from dataclass
+        return response.memories
+
+    def get_memory_service_info(self) -> Dict[str, Any]:
+        """
+        Returns information about this memory service.
+        """
+        return {
+            "service_type": "JsonFileMemoryService",
+            "description": "Stores session memory in a local JSON file.",
+            "filepath": self.filepath,
+            "current_session_count": len(self._sessions),
+            "capabilities": {"persistence": True, "search_type": "basic_substring"},
+        }

--- a/code_agent/agent/software_engineer/software_engineer/prompt.py
+++ b/code_agent/agent/software_engineer/software_engineer/prompt.py
@@ -51,6 +51,32 @@ ROOT_AGENT_INSTR = """
 - If the user asks for help with documentation, transfer to the agent `documentation_agent`
 - If the user asks about deployment, CI/CD, or DevOps practices, transfer to the agent `devops_agent`
 
+## Long-Term Memory Access:
+- Your conversations are periodically saved to a long-term memory store, **containing facts, decisions, and context from previous sessions.**
+- **You MUST use the `load_memory` tool to answer questions about information from past interactions or sessions.**
+- Provide a natural language `query` to the `load_memory` tool describing the information you need (e.g., `load_memory(query="discussion about Project Alpha last week")`, `load_memory(query="user's favorite language")`).
+- The tool will search the memory and return relevant snippets from past interactions.
+- Use this tool when the user asks questions that require recalling information beyond the current immediate conversation (e.g., "What did we decide about the API design yesterday?", "Remind me about the goals for feature X", "What is my favorite language?").
+- **Do not guess or state that you cannot remember past information. Use the `load_memory` tool.**
+- Note: This is for retrieving past information. Context within the *current* session (like the most recently read file) should be tracked via your reasoning and the conversation history.
+
+# --- Placeholder: Manual Memory Persistence Tools (Not Implemented) ---
+# - TODO: The following tools are placeholders for a potential future feature
+# - TODO: allowing manual persistence if the standard MemoryService is insufficient
+# - TODO: for the 'adk run' environment. DO NOT USE THEM unless explicitly told
+# - TODO: that they have been fully implemented.
+#
+# - `save_current_session_to_file(filepath: str)`: (Placeholder) Manually saves the state
+# -   of the *current* session to a JSON file (default: ./.manual_agent_memory.json).
+# -   Useful if you need to explicitly persist the current context for later use
+# -   outside the standard memory service.
+#
+# - `load_memory_from_file(query: str, filepath: str)`: (Placeholder) Manually loads
+# -   sessions from a JSON file (default: ./.manual_agent_memory.json) and searches
+# -   them based on the query. Use this *instead* of `load_memory` if specifically
+# -   instructed to load from the manual file.
+# --- End Placeholder ---
+
 ## Other Tools:
 - If you cannot delegate the request to a sub-agent, or if the query is about a general topic you don't know, use the `google_search_grounding` tool to find the information.
 

--- a/code_agent/agent/software_engineer/software_engineer/tools/__init__.py
+++ b/code_agent/agent/software_engineer/software_engineer/tools/__init__.py
@@ -20,3 +20,59 @@ from .code_analysis import (
 
 # Export the code search tool for easier imports
 from .code_search import codebase_search_tool
+
+# Export filesystem tools
+from .filesystem import (
+    read_file_tool,
+    list_dir_tool,
+    edit_file_tool,
+    configure_approval_tool,
+)
+
+# Export shell command tools
+from .shell_command import (
+    check_command_exists_tool,
+    check_shell_command_safety_tool,
+    configure_shell_approval_tool,
+    configure_shell_whitelist_tool,
+    execute_vetted_shell_command_tool,
+)
+
+# Export search tools
+from .search import google_search_grounding
+
+from .system_info import get_os_info_tool
+
+# Import system info tools
+
+# Import the placeholder memory persistence tools
+from .persistent_memory_tool import (
+    save_current_session_to_file_tool,
+    load_memory_from_file_tool,
+)
+
+__all__ = [
+    # Filesystem Tools
+    "read_file_tool",
+    "list_dir_tool",
+    "edit_file_tool",
+    "configure_approval_tool",
+    # Shell Command Tools
+    "check_command_exists_tool",
+    "check_shell_command_safety_tool",
+    "configure_shell_approval_tool",
+    "configure_shell_whitelist_tool",
+    "execute_vetted_shell_command_tool",
+    # Code Analysis Tools (add if needed by root agent, or keep in sub-agent)
+    # "analyze_code_tool",
+    # "get_analysis_issues_by_severity_tool",
+    # "suggest_code_fixes_tool",
+    # Search Tools
+    "google_search_grounding",
+    "codebase_search_tool",
+    # System Info Tools
+    "get_os_info_tool",
+    # Placeholder Persistent Memory Tools
+    "save_current_session_to_file_tool",
+    "load_memory_from_file_tool",
+]

--- a/code_agent/agent/software_engineer/software_engineer/tools/persistent_memory_tool.py
+++ b/code_agent/agent/software_engineer/software_engineer/tools/persistent_memory_tool.py
@@ -1,0 +1,155 @@
+"""Placeholder tools for manually saving/loading session memory to a file."""
+
+import logging
+from typing import Any, Dict
+
+from google.adk.tools import FunctionTool, ToolContext
+
+logger = logging.getLogger(__name__)
+
+# Default path for the memory file, could be configurable
+DEFAULT_MEMORY_FILE = "./.manual_agent_memory.json"
+
+# === Tool Implementation Functions (Commented Out) ===
+
+
+def _save_current_session_to_file_impl(tool_context: ToolContext, filepath: str = DEFAULT_MEMORY_FILE) -> Dict[str, str]:
+    """
+    (Placeholder) Saves the *current* session's state to a specified JSON file.
+    NOTE: This is a placeholder and not fully implemented.
+
+    Args:
+        tool_context: The ADK tool context containing session information.
+        filepath: The path to the JSON file where the session should be saved.
+
+    Returns:
+        A dictionary indicating the status of the operation.
+    """
+    # TODO: Implement this tool if manual file-based persistence is needed
+    #       for the standard 'adk run' environment.
+    # Implications:
+    #   - Requires agent to be explicitly prompted to call this tool.
+    #   - Overwrites the file with only the *current* session, or needs logic
+    #     to merge with existing sessions in the file.
+    #   - Doesn't integrate with the ADK's built-in MemoryService.
+    #   - Needs robust error handling (file I/O, JSON serialization).
+
+    logger.warning("Tool 'save_current_session_to_file' is a placeholder and not implemented.")
+    # --- Begin Commented Implementation Example ---
+    # if not hasattr(tool_context, 'session') or not tool_context.session:
+    #     msg = "No active session found in tool_context."
+    #     logger.error(msg)
+    #     return {"status": "error", "message": msg}
+    #
+    # session: Session = tool_context.session
+    # logger.info(f"Attempting to save session {session.session_id} to {filepath}...")
+    #
+    # # Logic to load existing data, add/update the current session, and save back
+    # existing_data = {}
+    # if os.path.exists(filepath):
+    #     try:
+    #         with open(filepath, 'r', encoding='utf-8') as f:
+    #             existing_data = json.load(f)
+    #         logger.debug(f"Loaded {len(existing_data)} sessions from {filepath}")
+    #     except (IOError, json.JSONDecodeError) as e:
+    #         logger.error(f"Error reading existing memory file {filepath}: {e}. Overwriting may occur.")
+    #
+    # session_key = f"{session.app_name}_{session.user_id}_{session.session_id}"
+    # existing_data[session_key] = session.model_dump(mode='json')
+    #
+    # try:
+    #     os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    #     with open(filepath, 'w', encoding='utf-8') as f:
+    #         json.dump(existing_data, f, indent=4)
+    #     logger.info(f"Successfully saved session {session.session_id} to {filepath}.")
+    #     return {"status": "success", "message": f"Session saved to {filepath}"}
+    # except (IOError, TypeError) as e:
+    #     msg = f"Error writing memory file {filepath}: {e}"
+    #     logger.error(msg)
+    #     return {"status": "error", "message": msg}
+    # --- End Commented Implementation Example ---
+    return {"status": "skipped", "message": "Tool is not implemented."}
+
+
+def _load_memory_from_file_impl(query: str, filepath: str = DEFAULT_MEMORY_FILE) -> Dict[str, Any]:
+    """
+    (Placeholder) Loads memory from a JSON file and performs a simple query.
+    NOTE: This is a placeholder and not fully implemented.
+
+    Args:
+        query: The natural language query to search for in stored messages.
+        filepath: The path to the JSON file containing stored sessions.
+
+    Returns:
+        A dictionary containing the search results or an error message.
+    """
+    # TODO: Implement this tool if manual file-based persistence is needed
+    #       for the standard 'adk run' environment.
+    # Implications:
+    #   - Requires agent to be explicitly prompted to call this tool instead of load_memory.
+    #   - Requires careful design of the query mechanism (e.g., simple substring search).
+    #   - Doesn't integrate with the ADK's built-in MemoryService.
+    #   - Needs robust error handling (file I/O, JSON deserialization, search logic).
+
+    logger.warning("Tool 'load_memory_from_file' is a placeholder and not implemented.")
+    # --- Begin Commented Implementation Example ---
+    # if not os.path.exists(filepath):
+    #     msg = f"Memory file not found: {filepath}"
+    #     logger.error(msg)
+    #     return {"status": "error", "message": msg, "results": []}
+    #
+    # try:
+    #     with open(filepath, 'r', encoding='utf-8') as f:
+    #         stored_sessions_data: Dict[str, Dict[str, Any]] = json.load(f)
+    #     logger.info(f"Loaded {len(stored_sessions_data)} sessions from {filepath} for query: '{query}'")
+    # except (IOError, json.JSONDecodeError) as e:
+    #     msg = f"Error reading memory file {filepath}: {e}"
+    #     logger.error(msg)
+    #     return {"status": "error", "message": msg, "results": []}
+    #
+    # results: List[Dict[str, Any]] = []
+    # query_lower = query.lower()
+    #
+    # for session_key, session_data in stored_sessions_data.items():
+    #     try:
+    #         # Minimal validation - check for history
+    #         history = session_data.get('history', [])
+    #         if not history:
+    #             continue
+    #
+    #         session_matched = False
+    #         for message in history:
+    #             if isinstance(message, dict) and 'parts' in message:
+    #                 message_text = "".join(
+    #                     [part.get('text', '') for part in message['parts'] if isinstance(part, dict)]
+    #                 ).lower()
+    #                 if query_lower in message_text:
+    #                     session_matched = True
+    #                     break
+    #
+    #         if session_matched:
+    #             logger.debug(f"Found match in session {session_key}")
+    #             results.append({"session_key": session_key, "session_data": session_data})
+    #             # Limit results? Maybe return only the first few matches or most relevant?
+    #
+    #     except Exception as e:
+    #         logger.warning(f"Error processing session {session_key}: {e}. Skipping.")
+    #
+    # logger.info(f"Found {len(results)} relevant session(s) for query: '{query}'")
+    # return {"status": "success", "results": results}
+    # --- End Commented Implementation Example ---
+    return {"status": "skipped", "message": "Tool is not implemented.", "results": []}
+
+
+# === Tool Definitions ===
+
+# Wrap the placeholder functions with FunctionTool
+save_current_session_to_file_tool = FunctionTool(
+    func=_save_current_session_to_file_impl,
+    # Name and description are inferred from the function docstring
+)
+
+load_memory_from_file_tool = FunctionTool(
+    func=_load_memory_from_file_impl,
+    # Name and description are inferred from the function docstring
+)

--- a/docs/plan_adk_memory.md
+++ b/docs/plan_adk_memory.md
@@ -1,0 +1,142 @@
+## Plan: Integrating Session Memory into Software Engineer Agent
+
+This plan describes the steps for an agent to integrate session memory, improving its ability to maintain context and track task progress across user interactions.
+
+**Prerequisite:** The agent environment and its underlying framework (ADK) must provide access to a session memory mechanism (e.g., `tool_context.session_state`). The agent's code needs to be structured such that it can be conceptually "modified" according to this plan.
+
+---
+
+### Step 1: Define Memory Schema and Use Cases
+
+*   **Objective:** Identify specific pieces of information from interactions that are valuable to remember and decide on a structure (schema) for storing them in session memory.
+*   **Implementation:**
+    *   List key pieces of context to store, e.g:
+        *   `current_project_path`: Path to the user's current project directory.
+        *   `current_file_being_discussed`: Path to the file the user is currently focused on.
+        *   `task_in_progress`: Details of a multi-step task (e.g., debugging, feature implementation) and its current state.
+        *   `recent_search_results`: Results from recent file reads or code searches.
+        *   `user_preferences`: User-specific settings or habits.
+    *   Decide on keys and data types for storing this information in a dictionary or similar structure within session memory. Example structure:
+        ```python
+        # Conceptual memory structure
+        memory = {
+            "context": {
+                "project_path": None,
+                "current_file": None
+            },
+            "tasks": {
+                "active_task": None, # e.g., {"type": "debugging", "step": "analyze_logs", "related_files": [...]}
+                "completed_tasks": []
+            },
+            "history": {
+                "last_read_file": None,
+                "last_search_query": None
+            }
+            # Add other relevant fields
+        }
+        ```
+*   **Verification:**
+    *   The agent internally confirms the defined schema and use cases are documented or represented in its configuration/code logic. This is a design step verification.
+
+---
+
+### Step 2: Implement Writing to Memory
+
+*   **Objective:** Modify agent logic to write relevant information to session memory after performing actions or receiving key information from the user.
+*   **Implementation:**
+    *   Identify points in the agent's workflow where memory should be updated (e.g., after successfully reading a file, after the user specifies a project directory, after starting a new multi-step task).
+    *   Add code snippets at these points to update the session memory object.
+    ```python
+    # Example conceptual code modification
+    def handle_read_file_success(self, filepath, content):
+        # ... handle file content ...
+        # Update memory
+        if self.tool_context and hasattr(self.tool_context, 'session_state'):
+             self.tool_context.session_state['memory']['context']['current_file'] = filepath
+             self.tool_context.session_state['memory']['history']['last_read_file'] = {'filepath': filepath, 'timestamp': current_time} # Optional: add timestamp
+        # ... rest of the handler ...
+    ```
+*   **Verification:**
+    *   In test scenarios, after an action that should trigger a memory write (e.g., reading a file), the agent immediately attempts to read the session memory back and asserts that the expected key-value pairs have been set correctly.
+    *   Use logging/debug output to inspect the contents of session memory after write operations.
+
+---
+
+### Step 3: Implement Reading from Memory
+
+*   **Objective:** Modify agent logic to read relevant information from session memory at the beginning of processing a user turn or before making decisions where past context is needed.
+*   **Implementation:**
+    *   At the start of processing a new user input, load relevant data from session memory into the agent's active state.
+    *   Access memory contents when deciding on the next action or formulating a response.
+    ```python
+    # Example conceptual code modification
+    def process_user_input(self, user_input):
+        # Load memory
+        current_context = {}
+        if self.tool_context and hasattr(self.tool_context, 'session_state') and 'memory' in self.tool_context.session_state:
+             current_context = self.tool_context.session_state['memory']['context']
+             # Load other relevant memory sections
+
+        # Use loaded context
+        if user_input == "read the file":
+            filepath_to_read = current_context.get('current_file')
+            if filepath_to_read:
+                self.read_file_content(filepath=filepath_to_read) # Use tool with remembered path
+            else:
+                # Ask the user for the file path
+                self.ask_for_filepath()
+        # ... rest of processing logic using memory ...
+    ```
+*   **Verification:**
+    *   In test scenarios designed to leverage memory (e.g., "read the file" after a file path was previously set in memory), verify that the agent correctly retrieves and uses the stored information instead of asking for it again.
+    *   Inspect agent's internal state or logs to confirm memory contents were loaded correctly.
+
+---
+
+### Step 4: Integrate Memory into Decision Making and Responses
+
+*   **Objective:** Adjust the agent's core logic and response generation to leverage the context retrieved from memory, leading to more coherent and context-aware interactions.
+*   **Implementation:**
+    *   Modify conditional logic to branch based on memory contents (e.g., if a task is in progress, continue that task; if `current_file` is set, default operations to that file).
+    *   Refine response templates to include references to past interactions or remembered context (e.g., "Continuing with debugging `login.py`...", "You previously asked about the `utils` directory...").
+*   **Verification:**
+    *   Run multi-turn test conversations where memory should influence the agent's behavior (e.g., asking a follow-up question about a file discussed earlier).
+    *   Observe the agent's responses and actions to ensure they are contextually appropriate and demonstrate memory usage.
+    *   The agent's behavior should be different and improved compared to the version without memory integration.
+
+---
+
+### Step 5: Develop Automated Test Cases
+
+*   **Objective:** Create a suite of automated tests (unit and integration) to ensure memory functionality works correctly and doesn't introduce regressions.
+*   **Implementation:**
+    *   Write unit tests for functions that specifically handle reading from and writing to session memory, mocking the memory object if necessary.
+    *   Write integration tests for key use cases involving multiple turns and memory persistence (e.g., set a file, ask about the file, set a task, ask about the task state).
+    *   Use a testing framework (e.g., `pytest`) and shell commands (`execute_vetted_shell_command`) to run these tests if the agent environment supports it.
+    ```python
+    # Conceptual shell command for running tests
+    # Check safety first!
+    # check_shell_command_safety(command='pytest agent_tests/')
+    # execute_vetted_shell_command(command='pytest agent_tests/')
+    ```
+*   **Verification:**
+    *   The agent runs the automated test suite.
+    *   Verification is successful if all tests pass, indicating correct memory handling in tested scenarios.
+
+---
+
+### Step 6: Manual Testing and Refinement
+
+*   **Objective:** Conduct realistic manual testing of the agent in various scenarios to catch issues not covered by automated tests and refine the memory usage based on practical interaction.
+*   **Implementation:**
+    *   Interact with the agent in typical software engineering workflows, intentionally leveraging the features enhanced by memory (e.g., extended debugging sessions, working on a feature over multiple turns, switching between tasks).
+    *   Gather feedback from other potential users (if available).
+*   **Verification:**
+    *   Observe the agent's behavior during manual testing.
+    *   Memory usage feels natural and helpful to the user.
+    *   Identify any instances where memory is misused, irrelevant information is remembered, or crucial information is forgotten.
+    *   Refine the memory schema, writing triggers, reading logic, and integration based on testing outcomes.
+
+---
+
+By following these steps, an agent can systematically integrate and verify the use of session memory, becoming a more powerful and context-aware assistant for software engineers.

--- a/docs/testing_strategies.md
+++ b/docs/testing_strategies.md
@@ -1,0 +1,45 @@
+# Testing Strategies for Code Agent
+
+This document outlines the approaches used for testing the Code Agent project.
+
+## Unit Tests
+
+-   **Location:** `tests/unit/`
+-   **Purpose:** Verify the correctness of individual functions, classes, and modules in isolation.
+-   **Framework:** `pytest`
+-   **Execution:** `uv run pytest tests/unit/`
+
+## Integration Tests
+
+-   **Location:** `tests/integration/`
+-   **Purpose:** Test the interaction between different components of the agent, including agent logic, tools, and potentially external services (mocked where appropriate).
+-   **Framework:** `pytest`
+-   **Execution:** `uv run pytest tests/integration/`
+
+### Memory Integration Testing (`tests/integration/test_memory_integration.py`)
+
+Testing the agent's memory capabilities requires understanding the distinction between different execution runtimes and memory service types:
+
+*   **Execution Runtimes:**
+    *   **`pytest` Environment:** When running tests programmatically using `pytest` (like in `test_memory_integration.py`), we manually instantiate the `Runner`, `SessionService`, and `MemoryService`. This gives fine-grained control but might not perfectly replicate the environment set up by the `adk run` CLI.
+    *   **`adk run` CLI Environment:** When running the agent via the command line (`uv run adk run ...`), the ADK framework manages the setup of services, potentially using default configurations.
+
+*   **`InMemoryMemoryService` Limitations:**
+    *   The default `google.adk.memory.InMemoryMemoryService` stores information only within the current running process.
+    *   When using `adk run` in scripts like `run_e2e_tests.sh`, each agent invocation is typically a separate process. Therefore, `InMemoryMemoryService` **cannot** be used to test *cross-session* memory recall in this E2E script because the memory is lost when each `adk run` process exits.
+    *   The `Runner`, when configured with `InMemoryMemoryService` programmatically (in `pytest`), is expected to handle adding session information to the memory implicitly. However, current integration tests (`test_agent_load_memory_e2e`) show that the agent is failing to utilize the `load_memory` tool effectively in this setup, possibly due to LLM reasoning or subtle framework interactions. Debugging this specific test setup is ongoing.
+
+*   **Current Status:**
+    *   `test_memory_integration` (the original test function): Verifies lower-level memory service interactions (using a custom `get_memory_service()` potentially returning a custom wrapper or the standard service, interacting via non-standard `.add()`/`.search()`).
+    *   `test_agent_load_memory_e2e`: Attempts to test the agent's use of the standard `load_memory` tool with `InMemoryMemoryService` in a programmatic `pytest` context. This test is currently **failing** because the agent does not call `load_memory` as expected.
+    *   `run_e2e_tests.sh`: **Cannot** currently test cross-session memory recall due to the limitations of `InMemoryMemoryService` with the `adk run` process isolation.
+
+*   **Future E2E Memory Testing:** To properly test cross-session memory recall in the `run_e2e_tests.sh` script, we need to investigate configuring `adk run` to use a **persistent `MemoryService`** (e.g., `VertexAiRagMemoryService`).
+
+## End-to-End (E2E) Tests
+
+-   **Location:** `scripts/run_e2e_tests.sh`
+-   **Purpose:** Simulate user interactions with the agent via the `adk run` command-line interface, testing the complete flow from user input to agent response and side effects (like file creation or command execution).
+-   **Framework:** Shell script invoking `adk run`.
+-   **Execution:** `bash scripts/run_e2e_tests.sh`
+-   **Limitations:** As noted above, currently cannot test cross-session memory recall using the default `InMemoryMemoryService`. 

--- a/scripts/run_e2e.py
+++ b/scripts/run_e2e.py
@@ -1,0 +1,210 @@
+"""
+Script to run the Software Engineer agent programmatically for E2E testing,
+allowing injection of specific SessionService and MemoryService implementations.
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+# Import memory services
+from google.adk.memory import (
+    BaseMemoryService,
+    InMemoryMemoryService,
+    VertexAiRagMemoryService,
+)
+from google.adk.runners import Runner
+
+# from google.adk.cli.run import run_stdio_async # REMOVED
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part  # Import genai types
+
+# Import the custom JSON memory service
+from code_agent.adk.json_memory_service import JsonFileMemoryService
+
+# Import the agent definition
+from code_agent.agent.software_engineer.software_engineer.agent import root_agent
+
+# Setup basic logging - Will be reconfigured in main
+# logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)  # Get logger for this module
+
+
+async def main(log_level_arg: str):
+    """Sets up services and runs the agent for a single input from stdin."""
+
+    # Configure logging based on argument
+    log_level = getattr(logging, log_level_arg.upper(), logging.INFO)
+    # Configure root logger
+    logging.basicConfig(level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    # Apply level to our specific logger too (optional, but good practice)
+    logger.setLevel(log_level)
+
+    app_name = os.getenv("ADK_E2E_APP_NAME", "e2e_test_app")
+    gcp_project = os.getenv("ADK_E2E_GCP_PROJECT")
+    gcp_location = os.getenv("ADK_E2E_GCP_LOCATION")
+    rag_corpus_id = os.getenv("ADK_E2E_RAG_CORPUS_ID")
+    json_path_e2e = os.getenv("ADK_E2E_JSON_MEMORY_PATH")
+    memory_service_type = os.getenv("ADK_E2E_MEMORY_SERVICE", "in_memory").lower()
+
+    # Initialize Services
+    session_service = InMemorySessionService()
+    memory_service: BaseMemoryService  # Use BaseMemoryService for type hint
+
+    if memory_service_type == "vertex_ai_rag" and gcp_project and gcp_location and rag_corpus_id:
+        logger.info(f"Using VertexAiRagMemoryService (Corpus ID: {rag_corpus_id}) - NOTE: Ensure constructor is correct")
+        try:
+            # Attempting initialization without rag_corpus_id first
+            # memory_service = VertexAiRagMemoryService(rag_corpus_id=rag_corpus_id) # type: ignore
+            # Check ADK documentation for correct VertexAiRagMemoryService constructor arguments
+            memory_service = VertexAiRagMemoryService()
+        except ImportError:
+            logger.error("google-adk[vertexai] is required for VertexAiRagMemoryService.")
+            sys.exit(1)
+    elif memory_service_type == "json_file" and json_path_e2e:
+        logger.info(f"Using JsonFileMemoryService with path: {json_path_e2e}")
+        memory_service = JsonFileMemoryService(filepath=json_path_e2e)
+    else:  # Default to in_memory
+        if memory_service_type != "in_memory":
+            logger.warning(f"Invalid or incomplete config for ADK_E2E_MEMORY_SERVICE='{memory_service_type}'. Defaulting to InMemoryMemoryService.")
+        logger.info("Using InMemoryMemoryService.")
+        memory_service = InMemoryMemoryService()
+
+    # Configure the runner
+    runner = Runner(
+        agent=root_agent,
+        app_name=app_name,
+        session_service=session_service,
+        memory_service=memory_service,  # Inject the chosen memory service
+    )
+
+    # --- Create the session ---
+    # Use consistent IDs for piped execution unless overridden
+    session_id = os.getenv("ADK_E2E_SESSION_ID", "e2e_piped_session")
+    user_id = os.getenv("ADK_E2E_USER_ID", "e2e_piped_user")
+    logger.info(f"Ensuring session exists: user='{user_id}', session='{session_id}' for app='{app_name}'")
+    session_service.create_session(app_name=app_name, user_id=user_id, session_id=session_id)
+
+    # --- Process Single Input from Stdin ---
+    # logger.info(f"Processing single input for agent '{root_agent.name}', session '{session_id}'...") # Already logged by session creation
+    try:
+        # Read the first line from stdin directly (blocking)
+        first_line = sys.stdin.readline().strip()
+
+        if not first_line or first_line.lower() in ["exit", "quit"]:
+            logger.info("No input or exit command received. Exiting.")
+            return  # Exit cleanly
+
+        logger.debug(f"Input received: {first_line}")  # Use debug for raw input
+        user_message = Content(parts=[Part(text=first_line)], role="user")
+
+        # Call runner.run() once
+        # final_text = "(No response found)"
+        run_complete = False
+        # Change back to regular 'for' loop as runner.run seems to return sync generator
+        for event in runner.run(  # type: ignore # Linter struggles with runner.run generator type
+            user_id=user_id, session_id=session_id, new_message=user_message
+        ):
+            run_complete = True
+            # Check for the standard event.content attribute
+            final_text_found_in_event = False
+            if hasattr(event, "content") and event.content and hasattr(event.content, "parts") and event.content.parts:
+                try:
+                    response_parts = [p.text for p in event.content.parts if hasattr(p, "text") and p.text is not None]  # Ensure p.text is not None
+                    response_text = "".join(response_parts)
+                    if response_text:
+                        # Print final agent response clearly
+                        # Use print directly for final output, or logger.info if logs are primary output
+                        print(f"{response_text}")  # Keep final output clean
+                        # logger.info(f"Agent Response: {response_text}") # Alternative: Log final output
+                        # final_text = response_text
+                        final_text_found_in_event = True
+                except Exception as e:
+                    # Log errors and raw event structure at debug level
+                    logger.debug(f"Error processing event.content.parts: {e} - Event: {event}", exc_info=True)
+
+            if not final_text_found_in_event:
+                # Log raw event structure at debug level if no text found
+                logger.debug(f"Agent Event (raw structure): {event}")
+
+        if not run_complete:
+            print("Agent: (No response generated)")
+
+    except EOFError:
+        logger.info("EOF received, exiting.")
+    except KeyboardInterrupt:
+        logger.info("Interrupted, exiting.")
+    finally:
+        # --- Explicitly save memory state ---
+        # Retrieve the latest state of the session directly from the session service.
+        # Then, update the memory service's internal state and force a save.
+        # This bypasses the standard add_session_to_memory flow which might not be
+        # correctly triggered or populated by the runner in this non-interactive script context.
+        try:
+            completed_session = session_service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
+            # --- DETAILED LOGGING ---
+            logger.info(f"Retrieved session object in finally block. Type: {type(completed_session)}")
+            if completed_session:
+                logger.info(f"Attributes via dir(): {dir(completed_session)}")
+                try:
+                    # Try dumping if it's a Pydantic model
+                    logger.info(f"Session content via model_dump(): {completed_session.model_dump()}")
+                except AttributeError:
+                    logger.info("Session object does not have model_dump().")
+                except Exception as dump_err:
+                    logger.info(f"Error during model_dump(): {dump_err}")
+            else:
+                logger.info("completed_session object is None.")
+            # --- END DETAILED LOGGING ---
+
+            # logger.debug(f"Retrieved session object content: {completed_session}") # Keep debug for full object
+            if completed_session and isinstance(memory_service, JsonFileMemoryService):  # Check type before accessing private members
+                logger.info(f"Explicitly updating session {session_id} in JsonFileMemoryService.")
+                # Directly update the internal dict
+                # Use try-except around potentially failing attribute access
+                try:
+                    key = memory_service._get_session_key(completed_session)
+                    memory_service._sessions[key] = completed_session
+                    logger.info(f"Forcing save to JSON file: {memory_service.filepath}")
+                    memory_service._save_to_json()  # Force save
+                except AttributeError as ae:
+                    logger.error(f"AttributeError accessing session attributes needed for saving: {ae}")
+                except Exception as save_err:
+                    logger.error(f"Unexpected error updating/saving session in memory service: {save_err}")
+            elif completed_session:
+                logger.warning(f"Memory service is not JsonFileMemoryService ({type(memory_service)}), cannot force save.")
+            else:
+                logger.warning(f"Could not retrieve session {session_id} from session service in finally block.")
+        except Exception as e:
+            logger.error(f"Error during final session saving for {session_id}: {e}", exc_info=True)
+        # ------------------------------------------
+    logger.info("Agent run finished.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run ADK Agent E2E Test Script")
+    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="Set the logging level (default: INFO)")
+    args = parser.parse_args()
+
+    # Read ENV VARS before calling main()
+    memory_service_type_env = os.getenv("ADK_E2E_MEMORY_SERVICE", "in_memory").lower()
+    gcp_project_env = os.getenv("ADK_E2E_GCP_PROJECT")
+    gcp_location_env = os.getenv("ADK_E2E_GCP_LOCATION")
+
+    # Ensure GOOGLE_GENAI_USE_VERTEXAI is set if using Vertex AI models/services
+    if memory_service_type_env == "vertex_ai_rag":
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+        if "GOOGLE_CLOUD_PROJECT" not in os.environ and gcp_project_env:
+            os.environ["GOOGLE_CLOUD_PROJECT"] = gcp_project_env
+        if "GOOGLE_CLOUD_LOCATION" not in os.environ and gcp_location_env:
+            os.environ["GOOGLE_CLOUD_LOCATION"] = gcp_location_env
+
+    # Run the main async function
+    try:
+        # Pass parsed log level to main
+        asyncio.run(main(log_level_arg=args.log_level))
+    except Exception as e:
+        logger.critical(f"Unhandled exception during script execution: {e}", exc_info=True)
+        sys.exit(1)

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -3,14 +3,57 @@
 
 set -e  # Exit on any error
 
-# Function to run agent command
+# --- Clean up previous memory file ---
+rm -f ./.e2e_memory_store.json
+
+# --- Helper Functions ---
+assert_output() {
+    local output="$1"
+    local expected="$2"
+    local test_name="$3"
+    echo "Asserting output for: $test_name"
+    if echo "$output" | grep -q -F -- "$expected"; then
+        echo "  [PASS] Output contains '$expected'"
+    else
+        echo "  [FAIL] Output did not contain '$expected'"
+        echo "--- Output ---"
+        echo "$output"
+        echo "--------------"
+        # Optionally exit script on failure: exit 1
+        exit 1
+    fi
+}
+
+# --- Configuration for Memory Service (Modify as needed for persistent tests) ---
+export E2E_LOG_LEVEL="INFO" # Set to DEBUG for verbose output
+
+# --- Option 1: Vertex AI RAG (Cloud-based, requires setup) ---
+# export ADK_E2E_MEMORY_SERVICE="vertex_ai_rag"
+# export ADK_E2E_GCP_PROJECT="your-gcp-project-id"
+# export ADK_E2E_GCP_LOCATION="us-central1"
+# export ADK_E2E_RAG_CORPUS_ID="your-rag-corpus-id"
+# export ADK_E2E_APP_NAME="e2e_vertex_rag_test_app" # Optional: Distinct app name
+# export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json" # Ensure ADC is set up for Vertex AI
+
+# --- Option 2: JSON File (Local, simple persistence) ---
+# Uncomment these lines to use the local JSON file for memory persistence
+export ADK_E2E_MEMORY_SERVICE="json_file"
+export ADK_E2E_JSON_MEMORY_PATH="./.e2e_memory_store.json" # Path relative to workspace root
+export ADK_E2E_APP_NAME="e2e_json_file_test_app" # Optional: Distinct app name
+
+# Default remains InMemoryMemoryService if nothing else is configured
+
+# Ensure google-adk[vertexai] is installed if using Vertex AI RAG service
+# uv pip install "google-adk[vertexai]"
+
+# --- Test Execution --- Function to run agent command
 run_agent_cmd() {
     echo "------------------------------------------------"
     echo "COMMAND: $1"
     echo "------------------------------------------------"
-    # Pipe the command (including the \nexit) into the adk runner
-    # Use || true to continue script even if the agent interaction fails
-    echo -e "$1\nexit" | uv run adk run code_agent/agent/software_engineer/software_engineer || true
+    # Pipe the command (including the \nexit) into the custom runner script
+    # Pass the log level to the Python script
+    echo -e "$1\nexit" | uv run python scripts/run_e2e.py --log-level="$E2E_LOG_LEVEL"
     echo "================================================"
     # Add a small delay to allow logs to flush if needed
     sleep 1
@@ -29,7 +72,8 @@ uv run code-agent --version
 echo "================================================"
 echo "Testing memory integration..."
 echo "================================================"
-uv run python tests/integration/test_memory_integration.py
+# Run using pytest to execute the test functions within the file
+uv run pytest tests/integration/test_memory_integration.py
 
 # echo "================================================"
 echo "Testing basic chat command with ADK..."
@@ -93,5 +137,53 @@ echo "CLEANUP: Removing generated test files..."
 echo "================================================"
 # Use standard rm, potentially run via agent if testing deletion itself
 rm -f sample_code.py test_sample.py Dockerfile || echo "Cleanup: No files to remove or error during removal."
+
+# === Memory Recall Tests (REQUIRES PERSISTENT MEMORY SERVICE) ===
+# The following tests invoke the agent multiple times. For memory
+# to persist between these runs, you MUST configure and export
+# environment variables for a persistent MemoryService (e.g., Vertex AI RAG)
+# at the top of this script. Using the default InMemoryMemoryService
+# will cause these assertions to FAIL.
+
+echo "================================================"
+echo "TEST: Memory Recall - Simple Fact (Requires Persistent Memory)"
+echo "================================================"
+
+# Run 1: Store the fact
+store_cmd="My favorite language is Python."
+echo "Storing fact: $store_cmd"
+export ADK_E2E_SESSION_ID="e2e_memory_store_fact_1"
+run_agent_cmd "$store_cmd"
+
+# Run 2: Recall the fact
+recall_cmd="What did I say my favorite language was?"
+echo "Recalling fact: $recall_cmd"
+export ADK_E2E_SESSION_ID="e2e_memory_recall_fact_1"
+recall_output=$(run_agent_cmd "$recall_cmd")
+assert_output "$recall_output" "Python" "Simple Fact Recall"
+
+echo "================================================"
+echo "TEST: Memory Recall - File Context (Requires Persistent Memory)"
+echo "================================================"
+
+# Ensure sample_code.py exists from previous steps
+
+# Run 1: Discuss the file
+store_file_cmd="Read the file sample_code.py"
+echo "Storing file context: $store_file_cmd"
+export ADK_E2E_SESSION_ID="e2e_memory_store_file_1"
+run_agent_cmd "$store_file_cmd"
+
+# Run 2: Ask about the file context
+recall_file_cmd="What was the name of the function in the file we just discussed?"
+echo "Recalling file context: $recall_file_cmd"
+export ADK_E2E_SESSION_ID="e2e_memory_recall_file_1"
+recall_file_output=$(run_agent_cmd "$recall_file_cmd")
+# Check for the function name 'add' which should be recalled
+assert_output "$recall_file_output" "add" "File Context Recall"
+
+# === End Memory Recall Tests ===
+
+echo "================================================"
 
 echo "All end-to-end tests completed!"

--- a/tests/integration/test_memory_integration.py
+++ b/tests/integration/test_memory_integration.py
@@ -8,6 +8,7 @@ import pytest
 
 # Import ADK session service and event types
 from google.adk.events import Event
+from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai.types import Content, Part
 
@@ -15,6 +16,10 @@ from code_agent.adk import get_memory_service
 from code_agent.adk.memory import (
     SearchMemoryResponse,
 )
+
+# Assuming the main agent is importable and configured with load_memory tool
+# If not, we might need to define a simple test agent here.
+from code_agent.agent.software_engineer.software_engineer.agent import root_agent
 
 # Keep root_agent import for context if needed, though not directly interacted with
 
@@ -81,6 +86,87 @@ async def test_memory_integration(adk_session_service_memory_test: InMemorySessi
     assert len(memory_results.results) > 0, "Should have found results in memory from previous session"
 
     print("\nTest completed successfully!")
+
+
+# --- New Test for Agent E2E Memory Recall ---
+
+# Define constants for the new test
+APP_NAME_E2E = "agent_e2e_test_app"
+USER_ID_E2E = "agent_e2e_user"
+
+# Import the standard ADK service
+# from google.adk.memory import InMemoryMemoryService # Revert this
+
+# Import your custom/wrapper service getter
+
+
+@pytest.mark.xfail(reason="Agent currently does not reliably call load_memory in programmatic Runner context.")
+@pytest.mark.asyncio
+async def test_agent_load_memory_e2e(adk_session_service_memory_test: InMemorySessionService):
+    """Tests the agent's ability to recall info using the load_memory tool."""
+    print("\nStarting agent load_memory E2E test...")
+    session_service = adk_session_service_memory_test
+    # We need the actual MemoryService instance used by the runner
+    # Assuming get_memory_service() provides the intended singleton or correctly configured instance
+    memory_service = get_memory_service()  # Use the custom/wrapper service again
+    # memory_service = InMemoryMemoryService() # Instantiate standard ADK service
+
+    # Configure the runner with the agent and services
+    runner = Runner(
+        agent=root_agent,  # Use the actual agent we configured
+        app_name=APP_NAME_E2E,
+        session_service=session_service,
+        memory_service=memory_service,  # Provide the memory service
+    )
+
+    # 1. Interaction to store information
+    session1_id = "e2e_session_store"
+    session_service.create_session(app_name=APP_NAME_E2E, user_id=USER_ID_E2E, session_id=session1_id)
+    store_input = Content(parts=[Part(text="My favorite language is Python.")], role="user")
+
+    print(f"Running agent in session {session1_id} to store info...")
+    # Explicitly await and iterate - Use regular for loop
+    all_events_run1 = []
+    # runner.run likely returns a synchronous generator of events
+    for event in runner.run(user_id=USER_ID_E2E, session_id=session1_id, new_message=store_input):  # type: ignore
+        all_events_run1.append(event)
+
+    # Explicitly add the completed session to memory (mimics end-of-session hook)
+    # Note: In a real deployment, the ADK framework/runner might handle this automatically.
+    # The standard InMemoryMemoryService doesn't have add_session_to_memory, runner handles it.
+    # completed_session1 = session_service.get_session(app_name=APP_NAME_E2E, user_id=USER_ID_E2E, session_id=session1_id)
+    # Reinstate the call, assuming get_memory_service provides the method
+    # await memory_service.add_session_to_memory(completed_session1) # type: ignore # This method does not exist on the standard service
+    # print(f"Added session {session1_id} to memory service.")
+    # Relying on Runner to add session1 to memory_service implicitly
+
+    # 2. Interaction to recall information
+    session2_id = "e2e_session_recall"  # Can be the same or different session ID
+    session_service.create_session(app_name=APP_NAME_E2E, user_id=USER_ID_E2E, session_id=session2_id)
+    # Make the recall query more direct
+    # recall_input = Content(parts=[Part(text="Use memory to tell me my favorite language.")], role="user")
+    # Force the agent to call the tool directly for debugging
+    recall_input = Content(parts=[Part(text="Please call the load_memory tool with the query 'favorite language'.")], role="user")
+
+    print(f"Running agent in session {session2_id} to force tool call...")
+    final_response_text = ""
+    load_memory_called = False
+    # Explicitly await and iterate - Use regular for loop
+    all_events_run2 = []
+    # runner.run likely returns a synchronous generator of events
+    for event in runner.run(user_id=USER_ID_E2E, session_id=session2_id, new_message=recall_input):  # type: ignore
+        all_events_run2.append(event)
+        if event.get_function_calls() and any(fc.name == "load_memory" for fc in event.get_function_calls()):
+            load_memory_called = True
+        if event.is_final_response() and event.content and event.content.parts:
+            final_response_text = event.content.parts[0].text
+            break
+
+    # 3. Assertions
+    assert load_memory_called, "Agent should have called the load_memory tool."
+    assert "Python" in final_response_text, f"Agent did not recall the favorite language. Response: '{final_response_text}'"
+    print(f"Agent final response: '{final_response_text}'")
+    print("Agent load_memory E2E test completed successfully!")
 
 
 # Keep the main block if direct execution is desired, but update it


### PR DESCRIPTION
## Summary of Changes
This pull request introduces a `JsonFileMemoryService` to persist agent sessions to a JSON file, primarily for use in end-to-end (E2E) testing. This addresses the limitation of the `InMemoryMemoryService`, which does not persist data between separate `adk run` invocations in E2E scripts. The PR also includes modifications to the software engineer agent to integrate the built-in `load_memory` tool and provides placeholder tools for manual memory persistence. Additionally, the E2E testing script is updated to utilize the new `JsonFileMemoryService` and includes memory recall tests.

### Highlights
* **New Feature**: Adds a `JsonFileMemoryService` that persists agent sessions to a JSON file, enabling cross-session memory recall in E2E tests.
* **Tool Integration**: Integrates the built-in `load_memory` tool into the software engineer agent and introduces placeholder tools for manual memory persistence.
* **E2E Testing**: Updates the E2E testing script to utilize the `JsonFileMemoryService` and includes tests for memory recall.
* **Documentation**: Updates the architecture and testing strategies documentation to reflect the new memory service and testing approaches.

### Changelog
<details>
<summary>Click here to see the changelog</summary>

* **code_agent/adk/json_memory_service.py**
  * Introduces the `JsonFileMemoryService` class, which inherits from `BaseMemoryService`.
  * Implements methods for loading sessions from and saving sessions to a JSON file.
  * Includes `add_session_to_memory`, `load_memory`, `search_memory`, and `get_memory_service_info` methods.
  * Uses `ast.literal_eval` for safe evaluation of keys when loading from JSON.
  * Implements basic substring search for `load_memory`.
* **code_agent/agent/software_engineer/software_engineer/agent.py**
  * Imports the built-in `load_memory` tool from `google.adk.tools`.
  * Adds `load_memory` to the list of tools available to the agent.
  * Adds placeholder tools `save_current_session_to_file_tool` and `load_memory_from_file_tool`.
  * Introduces `initialize_session_memory` function to initialize session memory in the tool context.
* **code_agent/agent/software_engineer/software_engineer/prompt.py**
  * Adds instructions for the agent to use the `load_memory` tool to answer questions about past interactions.
  * Includes a description of the `load_memory` tool and its usage.
  * Adds a placeholder section for manual memory persistence tools, indicating they are not yet implemented.
* **code_agent/agent/software_engineer/software_engineer/tools/__init__.py**
  * Exports the filesystem, shell command, search, system info, and persistent memory tools for easier imports.
  * Defines `__all__` to specify the tools available for import.
* **code_agent/agent/software_engineer/software_engineer/tools/persistent_memory_tool.py**
  * Introduces placeholder tools for manually saving and loading session memory to a file.
  * Includes `save_current_session_to_file_tool` and `load_memory_from_file_tool`, which are not yet fully implemented.
  * Provides commented-out example implementations for these tools.
* **docs/getting_started_architecture.md**
  * Adds a section on E2E testing with `adk run`.
  * Includes diagrams illustrating the limitations of `InMemoryMemoryService` in E2E testing and the future state with a persistent `MemoryService`.
* **docs/plan_adk_memory.md**
  * Adds a plan for integrating session memory into the Software Engineer Agent, including steps for defining the memory schema, implementing read/write operations, and developing test cases.
* **docs/testing_strategies.md**
  * Adds documentation on testing strategies for the Code Agent, including unit, integration, and E2E tests.
  * Discusses the limitations of `InMemoryMemoryService` in E2E testing and the need for a persistent `MemoryService`.
* **scripts/run_e2e.py**
  * Modifies the E2E test script to allow injection of specific `SessionService` and `MemoryService` implementations.
  * Adds support for using `VertexAiRagMemoryService` and `JsonFileMemoryService` in E2E tests.
  * Includes logic to explicitly save the memory state after the agent run.
* **scripts/run_e2e_tests.sh**
  * Updates the E2E testing script to utilize the `JsonFileMemoryService`.
  * Adds memory recall tests that require a persistent `MemoryService`.
  * Includes helper functions for asserting output and configuring the memory service.
* **tests/integration/test_memory_integration.py**
  * Adds a new test, `test_agent_load_memory_e2e`, to test the agent's ability to recall information using the `load_memory` tool.
  * Marks the new test as expected to fail because the agent does not reliably call `load_memory` in the programmatic `Runner` context.

</details>